### PR TITLE
Fix deployment build failure - Move PostCSS dependencies to production

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,9 @@
     "vite": "^6.3.5",
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.47"
   },
   "devDependencies": {
     "@playwright/test": "^1.40.0",
@@ -107,13 +109,11 @@
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "@vitest/coverage-v8": "^3.2.3",
-    "autoprefixer": "^10.4.20",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "jsdom": "^23.0.1",
-    "postcss": "^8.4.47",
     "prettier": "^3.1.1",
     "tailwindcss-animate": "^1.0.7",
     "tsx": "^4.19.1",


### PR DESCRIPTION
## Problem
Deployment was failing with the error:
```
[Error] Loading PostCSS Plugin failed: Cannot find module 'autoprefixer'
```

## Solution
Moved `autoprefixer` and `postcss` from `devDependencies` to `dependencies` in package.json.

## Why this fixes the issue
- These packages are required during the build process
- Deployment environments often only install production dependencies
- PostCSS configuration requires these packages to be available during build

## Testing
- ✅ Local build now completes successfully
- ✅ All build artifacts are generated properly
- ✅ No breaking changes to existing functionality

## Changes
- Moved `autoprefixer: ^10.4.20` from devDependencies to dependencies
- Moved `postcss: ^8.4.47` from devDependencies to dependencies

This should resolve the deployment build failure and allow successful deployment to Render.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author