### PR TITLE
feat(storage): unify storage layer and introduce pluggable drivers

### DIFF
--- a/server/lib/storage/index.ts
+++ b/server/lib/storage/index.ts
@@ -1,0 +1,35 @@
+import { Readable } from "stream";
+
+export interface ObjectStore {
+  put(key: string, data: Buffer | Readable, mimeType?: string): Promise<void>;
+  get(key: string): Promise<Buffer | null>;
+  remove(key: string): Promise<void>;
+  list(prefix?: string): Promise<string[]>;
+}
+
+export type StoreDriver = "s3" | "supabase" | "local";
+
+export interface StoreOptions {
+  driver: StoreDriver;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { driver } = (process.env.STORAGE_DRIVER ? { driver: process.env.STORAGE_DRIVER } : { driver: "local" }) as StoreOptions;
+
+let store: ObjectStore;
+
+switch (driver) {
+  case "s3":
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    store = require("./s3").default;
+    break;
+  case "supabase":
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    store = require("./supabase").default;
+    break;
+  default:
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    store = require("./local").default;
+}
+
+export default store;

--- a/server/lib/storage/local.ts
+++ b/server/lib/storage/local.ts
@@ -1,0 +1,49 @@
+import fs from "fs/promises";
+import path from "path";
+import { ObjectStore } from ".";
+
+const baseDir = path.resolve(process.cwd(), "storage");
+
+async function ensureDir(filePath: string) {
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+}
+
+const LocalStore: ObjectStore = {
+  async put(key, data) {
+    const filePath = path.join(baseDir, key);
+    await ensureDir(filePath);
+    if (Buffer.isBuffer(data)) {
+      await fs.writeFile(filePath, data);
+    } else {
+      const chunks: Buffer[] = [];
+      for await (const chunk of data) chunks.push(Buffer.from(chunk));
+      await fs.writeFile(filePath, Buffer.concat(chunks));
+    }
+  },
+
+  async get(key) {
+    try {
+      const filePath = path.join(baseDir, key);
+      return await fs.readFile(filePath);
+    } catch {
+      return null;
+    }
+  },
+
+  async remove(key) {
+    await fs.rm(path.join(baseDir, key), { force: true });
+  },
+
+  async list(prefix = "") {
+    const dir = path.join(baseDir, prefix);
+    try {
+      const files = await fs.readdir(dir);
+      return files.map((f) => path.join(prefix, f));
+    } catch {
+      return [];
+    }
+  },
+};
+
+export default LocalStore;

--- a/server/lib/storage/s3.ts
+++ b/server/lib/storage/s3.ts
@@ -1,0 +1,28 @@
+import { S3Client, PutObjectCommand, GetObjectCommand, DeleteObjectCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
+import { Readable } from "stream";
+import { ObjectStore } from ".";
+
+const s3 = new S3Client({ region: process.env.AWS_REGION });
+const Bucket = process.env.S3_BUCKET!;
+
+const S3Store: ObjectStore = {
+  async put(key, data, mimeType) {
+    await s3.send(new PutObjectCommand({ Bucket, Key: key, Body: data, ContentType: mimeType }));
+  },
+  async get(key) {
+    const { Body } = await s3.send(new GetObjectCommand({ Bucket, Key: key }));
+    if (!Body) return null;
+    const chunks: Buffer[] = [];
+    for await (const chunk of Body as Readable) chunks.push(Buffer.from(chunk));
+    return Buffer.concat(chunks);
+  },
+  async remove(key) {
+    await s3.send(new DeleteObjectCommand({ Bucket, Key: key }));
+  },
+  async list(prefix = "") {
+    const { Contents } = await s3.send(new ListObjectsV2Command({ Bucket, Prefix: prefix }));
+    return (Contents || []).map((c) => c.Key!).filter(Boolean);
+  },
+};
+
+export default S3Store;

--- a/server/lib/storage/supabase.ts
+++ b/server/lib/storage/supabase.ts
@@ -1,0 +1,28 @@
+import { createClient } from "@supabase/supabase-js";
+import { Readable } from "stream";
+import { ObjectStore } from ".";
+
+const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_KEY!);
+const bucket = process.env.SUPABASE_BUCKET!;
+
+const SupabaseStore: ObjectStore = {
+  async put(key, data, mimeType) {
+    await supabase.storage.from(bucket).upload(key, data as any, { contentType: mimeType, upsert: true });
+  },
+  async get(key) {
+    const { data } = await supabase.storage.from(bucket).download(key);
+    if (!data) return null;
+    const chunks: Buffer[] = [];
+    for await (const chunk of data as Readable) chunks.push(Buffer.from(chunk));
+    return Buffer.concat(chunks);
+  },
+  async remove(key) {
+    await supabase.storage.from(bucket).remove([key]);
+  },
+  async list(prefix = "") {
+    const { data } = await supabase.storage.from(bucket).list(prefix);
+    return (data || []).map((d) => `${prefix}${d.name}`);
+  },
+};
+
+export default SupabaseStore;


### PR DESCRIPTION
### What
This PR introduces a new `server/lib/storage` module providing a single `ObjectStore` interface with concrete drivers for S3, Supabase, and the local filesystem. It lays the groundwork for removing the duplicated `storage.ts` and `database-storage.ts` files.

### Why
We currently have two parallel persistence abstractions which increases maintenance cost and causes confusion. Unifying them behind a single composable interface makes it easier to swap storage back-ends, improves testability, and removes ~2000 LOC of duplication in follow-up commits.

### Next steps (separate commits)
1. Refactor existing call-sites in `server/**` to use the new store.
2. Delete legacy storage modules.
3. Add dependency-injection via ENV `STORAGE_DRIVER`.

> Note: No production code is wired to the new store yet—so this is a safe, non-breaking merge.
